### PR TITLE
make pvnet ecmwf only name simple

### DIFF
--- a/pvnet_app/model_configs/all_models.yaml
+++ b/pvnet_app/model_configs/all_models.yaml
@@ -38,7 +38,7 @@ models:
         version: 9002baf1e9dc1ec141f3c4a1fa8447b6316a4558
     uses_satellite_data: False
 
-  - name: pvnet_v2-ecmwf-only-samples-v1
+  - name: pvnet_ecmwf # this name is important as it used for blending
     pvnet:
         repo: openclimatefix/pvnet_uk_region
         version: 0bc344fafb2232fb0b6bb0bf419f0449fe11c643


### PR DESCRIPTION
# Pull Request

## Description

Make pvnet ecmwf name simple.
This make it easier with blending

Helps with #123 

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
