### PR TITLE
Add hard max limit

### DIFF
--- a/pvnet_app/forecast_compiler.py
+++ b/pvnet_app/forecast_compiler.py
@@ -257,7 +257,7 @@ class ForecastCompiler:
 
         # check that maximum national is above 10% of national capacity.
         if da_abs_national.max() > 1.1 * self.national_capacity:
-            raise Exception(f'The Maximum of the national forecast is {da_abs_national.max().value} '
+            raise Exception(f'The Maximum of the national forecast is {da_abs_national.max().values} '
                             f'which is greater than 10% of the national capacity '
                             f'({self.national_capacity})')
 

--- a/pvnet_app/forecast_compiler.py
+++ b/pvnet_app/forecast_compiler.py
@@ -257,7 +257,7 @@ class ForecastCompiler:
 
         # check that maximum national is above 10% of national capacity.
         if da_abs_national.max() > 1.1 * self.national_capacity:
-            raise Exception(f'The Maximum of the national forecast is {da_abs_national.max()} '
+            raise Exception(f'The Maximum of the national forecast is {da_abs_national.max().value} '
                             f'which is greater than 10% of the national capacity '
                             f'({self.national_capacity})')
 

--- a/pvnet_app/forecast_compiler.py
+++ b/pvnet_app/forecast_compiler.py
@@ -255,6 +255,12 @@ class ForecastCompiler:
             f"National forecast is {da_abs_national.sel(output_label='forecast_mw').values}"
         )
 
+        # check that maximum national is above 10% of national capacity.
+        if da_abs_national.max() > 1.1 * self.national_capacity:
+            raise Exception(f'The Maximum of the national forecast is {da_abs_national.max()} '
+                            f'which is greater than 10% of the national capacity '
+                            f'({self.national_capacity})')
+
         # Store the compiled predictions internally
         self.da_abs_all = xr.concat([da_abs_national, da_abs], dim="gsp_id")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,7 +222,7 @@ def gsp_yields_and_systems(db_session, test_t0):
             gsp_yield_sql = GSPYield(
                 datetime_utc=(t0_datetime_utc + timedelta(minutes=minute)).replace(tzinfo=timezone.utc),
                 solar_generation_kw=np.random.randint(low=0, high=1000),
-                capacity_mwp=100,
+                capacity_mwp=installed_capacity_mw,
             ).to_orm()
             gsp_yield_sql.location = location_sql
             gsp_yields.append(gsp_yield_sql)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,10 +205,16 @@ def gsp_yields_and_systems(db_session, test_t0):
     gsp_yields = []
     locations = []
     for i in range(0, 318):
+
+        if i == 0:
+            installed_capacity_mw = 17000
+        else:
+            installed_capacity_mw = 17000/318
+        
         location_sql: LocationSQL = get_location(
             session=db_session,
             gsp_id=i,
-            installed_capacity_mw=123.0,
+            installed_capacity_mw = installed_capacity_mw,
         )
 
         # From 3 hours ago to 8.5 hours into future


### PR DESCRIPTION
# Pull Request

## Description

Add a hard limit, so if the maximum of the forecast is above 10% of the national capacity, dont let the forecast be fail, and let the app fail. 

#174 

## How Has This Been Tested?

Ci tests
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
