### PR TITLE
Validate forecast: detect and flag sudden fluctuations in forecasts a…

### DIFF
--- a/tests/test_forecast_compiler.py
+++ b/tests/test_forecast_compiler.py
@@ -13,8 +13,7 @@ def test_validate_forecast_ok():
     # Ccapture log messages in a list so assertions can be done on them if needed
     logs = []
 
-    def dummy_logger(msg: str):
-        logs.append(msg)
+    def dummy_logger(msg: str): logs.append(msg)
 
     # Forecast is significantly below capacity => no warnings or errors
     national_forecast_values = np.array([10, 20, 30])  # MW
@@ -82,8 +81,7 @@ def test_validate_forecast_sudden_fluctuations():
     # Mock logger to capture warnings
     logged_messages = []
 
-    def logger_func(message):
-        logged_messages.append(message)
+    def logger_func(message): logged_messages.append(message)
 
     national_capacity = 2000
 


### PR DESCRIPTION
### **Pull Request**  

## **Description**  
This PR adds validation to detect sudden fluctuations in forecast values. It flags cases where the forecast rises and then drops by a significant amount:  
- Logs a warning if the fluctuation is **≥250 MW up and down**  
- Raises an exception if the fluctuation is **≥500 MW up and down**  
- Includes corresponding test cases in `test_forecast_compiler.py`  

Fixes #184 

## **How Has This Been Tested?**  
- [x] Ran unit tests to verify that warnings and exceptions are triggered correctly.  
- [x] Ensured no false positives occur for normal forecast variations.  

## **Checklist:**  
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)  
- [x] I have performed a self-review of my own code  
- [x] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my fix is effective  
- [x] I have checked my code and corrected any misspellings  