### PR TITLE
clean up test database fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import xarray as xr
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest
 from nowcasting_datamodel.models import GSPYield, LocationSQL
-from nowcasting_datamodel.models.base import Base_Forecast, Base_PV
+from nowcasting_datamodel.models.base import Base_Forecast
 from nowcasting_datamodel.read.read import get_location
 from nowcasting_datamodel.models.forecast import (
     ForecastSQL,
@@ -40,7 +40,6 @@ def db_connection(test_t0, db_url):
     engine = database_connection.engine
 
     database_connection.create_all()
-    Base_PV.metadata.create_all(engine)
 
     with database_connection.get_session() as s:
         populate_db_session_with_input_data(s, test_t0)
@@ -48,7 +47,6 @@ def db_connection(test_t0, db_url):
     yield database_connection
 
     # Tear down
-    Base_PV.metadata.drop_all(engine)
     Base_Forecast.metadata.drop_all(engine)
 
     engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,81 +1,115 @@
+import pytest
 import os
 from datetime import UTC, timedelta
 
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest
-from nowcasting_datamodel.models import (
-    GSPYield,
-    LocationSQL,
-)
+from nowcasting_datamodel.models import GSPYield, LocationSQL
 from nowcasting_datamodel.models.base import Base_Forecast, Base_PV
 from nowcasting_datamodel.read.read import get_location
+from nowcasting_datamodel.models.forecast import (
+    ForecastSQL,
+    ForecastValueSQL,
+    ForecastValueLatestSQL,
+    ForecastValueSevenDaysSQL,
+)
 from testcontainers.postgres import PostgresContainer
+
 
 xr.set_options(keep_attrs=True)
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def test_t0():
     return pd.Timestamp.now(tz=None).floor(timedelta(minutes=30))
 
 
 @pytest.fixture(scope="session")
-def engine_url():
-    """Database engine, this includes the table creation."""
+def db_url(test_t0):
     with PostgresContainer("postgres:16.1") as postgres:
-        url = postgres.get_connection_url()
-        os.environ["DB_URL"] = url
-
-        database_connection = DatabaseConnection(url, echo=False)
-
-        engine = database_connection.engine
-
-        # Would like to do this here but found the data
-        # was not being deleted when using 'db_connection'
-        # database_connection.create_all()
-        # Base_PV.metadata.create_all(engine)
-
-        yield url
-
-        # Base_PV.metadata.drop_all(engine)
-        # Base_Forecast.metadata.drop_all(engine)
-
-        engine.dispose()
+        yield postgres.get_connection_url()
 
 
-@pytest.fixture()
-def db_connection(engine_url):
-    database_connection = DatabaseConnection(engine_url, echo=False)
+@pytest.fixture(scope="session")
+def db_connection(test_t0, db_url):
+    """Database engine, this includes the table creation."""
 
+    database_connection = DatabaseConnection(db_url, echo=False)
     engine = database_connection.engine
-    # connection = engine.connect()
-    # transaction = connection.begin()
 
-    # There should be a way to only make the tables once
-    # but make sure we remove the data
     database_connection.create_all()
     Base_PV.metadata.create_all(engine)
 
+    with database_connection.get_session() as s:
+        populate_db_session_with_input_data(s, test_t0)
+
     yield database_connection
 
-    # transaction.rollback()
-    # connection.close()
-
+    # Tear down
     Base_PV.metadata.drop_all(engine)
     Base_Forecast.metadata.drop_all(engine)
 
+    engine.dispose()
+
 
 @pytest.fixture()
-def db_session(db_connection, engine_url):
+def db_session(db_connection):
     """Return a sqlalchemy session, which tears down everything properly post-test."""
 
     with db_connection.get_session() as s:
-        s.begin()
+
         yield s
-        s.rollback()
+
+        # Remove forecasts made in the test
+        s.query(ForecastValueSevenDaysSQL).delete()
+        s.query(ForecastValueLatestSQL).delete()
+        s.query(ForecastValueSQL).delete()
+        s.query(ForecastSQL).delete()
+        s.commit()
+
+
+def populate_db_session_with_input_data(session, test_t0):
+    """Populate a session with input data for testing"""
+
+    num_gsps = 317
+    total_capacity_mw = 17_000
+
+    gsp_yields = []
+    for i in range(0, num_gsps+1):
+
+        # Capacity is total capacity for GSP 0. The rest of the GSPs share the capacity evenly
+        installed_capacity_mw = total_capacity_mw if i == 0 else total_capacity_mw/num_gsps
+
+        location_sql: LocationSQL = get_location(
+            session=session,
+            gsp_id=i,
+            installed_capacity_mw=installed_capacity_mw,
+        )
+
+        # GSP data is mostly up to date, but a bit delayed
+        for date in pd.date_range(
+            test_t0 - pd.Timedelta("18h"),
+            test_t0 - pd.Timedelta("6.5h"),
+            freq="30min",
+        ):
+            gsp_yield_sql = GSPYield(
+                datetime_utc=date.to_pydatetime().replace(tzinfo=UTC),
+                solar_generation_kw=np.random.randint(low=0, high=installed_capacity_mw*1000),
+                capacity_mwp=installed_capacity_mw,
+            ).to_orm()
+            gsp_yield_sql.location = location_sql
+            gsp_yields.append(gsp_yield_sql)
+
+    # Add recent GSP data to the database
+    session.add_all(gsp_yields)
+
+    # Add recent fake forecast error data to the database for the pvnet_v2 model
+    metric_values = make_fake_me_latest(session=session, model_name="pvnet_v2")
+    session.add_all(metric_values)
+
+    session.commit()
 
 
 def make_nwp_data(shell_path, varname, test_t0):
@@ -112,7 +146,7 @@ def make_nwp_data(shell_path, varname, test_t0):
     return ds
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def nwp_ukv_data(test_t0):
     return make_nwp_data(
         shell_path=f"{os.path.dirname(os.path.abspath(__file__))}/test_data/nwp_ukv_shell.zarr",
@@ -121,7 +155,7 @@ def nwp_ukv_data(test_t0):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def nwp_ecmwf_data(test_t0):
     return make_nwp_data(
         shell_path=f"{os.path.dirname(os.path.abspath(__file__))}/test_data/nwp_ecmwf_shell.zarr",
@@ -129,22 +163,18 @@ def nwp_ecmwf_data(test_t0):
         test_t0=test_t0,
     )
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def config_filename():
     return f"{os.path.dirname(os.path.abspath(__file__))}/test_data/test.yaml"
 
 
-def make_sat_data(test_t0, delay_mins, freq_mins, small=False):
+def make_sat_data(test_t0, delay_mins, freq_mins):
     # Load dataset which only contains coordinates, but no data
     ds = xr.open_zarr(
         f"{os.path.dirname(os.path.abspath(__file__))}/test_data/non_hrv_shell.zarr",
     )
 
-    if small:
-        # only select 10 by 10
-        ds = ds.isel(x_geostationary=slice(0, 10), y_geostationary=slice(0, 10))
-
-    # remove tim dim and expand time dim to be len 36 = 3 hours of 5 minute data
+    # Remove time dim and expand time dim to be len 36 = 3 hours of 5 minute data
     ds = ds.drop_vars("time")
     n_hours = 3
 
@@ -169,75 +199,27 @@ def make_sat_data(test_t0, delay_mins, freq_mins, small=False):
 
     return ds
 
-@pytest.fixture()
+
+@pytest.fixture(scope="session")
 def sat_5_data(test_t0):
     return make_sat_data(test_t0, delay_mins=10, freq_mins=5)
 
-@pytest.fixture()
+
+@pytest.fixture(scope="session")
 def sat_5_data_zero_delay(test_t0):
     return make_sat_data(test_t0, delay_mins=0, freq_mins=5)
 
-@pytest.fixture()
+
+@pytest.fixture(scope="session")
 def sat_5_data_delayed(test_t0):
     return make_sat_data(test_t0, delay_mins=120, freq_mins=5)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sat_15_data(test_t0):
     return make_sat_data(test_t0, delay_mins=0, freq_mins=15)
 
-@pytest.fixture()
-def sat_15_data_small(test_t0):
-    return make_sat_data(test_t0, delay_mins=0, freq_mins=15,small=True)
 
-
-@pytest.fixture()
-def gsp_yields_and_systems(db_session, test_t0):
-    """Create gsp yields and systems"""
-
-    # GSP data is mostly up to date, but 10 hours delayed
-    t0_datetime_utc = test_t0 - timedelta(hours=15)
-
-    # this pv systems has same coordiantes as the first gsp
-    gsp_yields = []
-    locations = []
-    for i in range(0, 318):
-
-        if i == 0:
-            installed_capacity_mw = 17000
-        else:
-            installed_capacity_mw = 17000/318
-
-        location_sql: LocationSQL = get_location(
-            session=db_session,
-            gsp_id=i,
-            installed_capacity_mw = installed_capacity_mw,
-        )
-
-        # From 3 hours ago to 8.5 hours into future
-        for minute in range(-3 * 60, 9 * 60, 30):
-            gsp_yield_sql = GSPYield(
-                datetime_utc=(t0_datetime_utc + timedelta(minutes=minute)).replace(tzinfo=UTC),
-                solar_generation_kw=np.random.randint(low=0, high=1000),
-                capacity_mwp=installed_capacity_mw,
-            ).to_orm()
-            gsp_yield_sql.location = location_sql
-            gsp_yields.append(gsp_yield_sql)
-            locations.append(location_sql)
-
-    # add to database
-    db_session.add_all(gsp_yields)
-
-    db_session.commit()
-
-    return {
-        "gsp_yields": gsp_yields,
-        "gs_systems": locations,
-    }
-
-
-@pytest.fixture()
-def me_latest(db_session):
-    metric_values = make_fake_me_latest(session=db_session, model_name="pvnet_v2")
-    db_session.add_all(metric_values)
-    db_session.commit()
+@pytest.fixture(scope="session")
+def sat_15_data_small(sat_15_data):
+    return sat_15_data.isel(x_geostationary=slice(0, 10), y_geostationary=slice(0, 10))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def test_t0():
 
 
 @pytest.fixture(scope="session")
-def db_url(test_t0):
+def db_url():
     with PostgresContainer("postgres:16.1") as postgres:
         yield postgres.get_connection_url()
 

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -203,7 +203,7 @@ def test_check_model_satellite_inputs_available(config_filename):
     assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_5)
 
 
-def test_extend_satellite_data_with_nans(sat_5_data, test_t0):
+def test_extend_satellite_data_with_nans(sat_5_data):
 
     # make temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -224,7 +224,7 @@ def test_extend_satellite_data_with_nans(sat_5_data, test_t0):
         assert (ds.time.values == time).all()
 
 
-def test_extend_satellite_data_with_nans_over_3_hours(sat_5_data, test_t0):
+def test_extend_satellite_data_with_nans_over_3_hours(sat_5_data):
 
     # make temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -277,6 +277,7 @@ def test_remove_satellite_data(sat_15_data_small, test_t0):
         os.chdir(tmpdirname)
 
         # make half the values zeros
+        sat_15_data_small = sat_15_data_small.copy(deep=True)
         sat_15_data_small.data[::2] = np.nan
 
         # Make 15-minutely satellite data available
@@ -341,6 +342,8 @@ def test_check_for_constant_values(sat_5_data):
 def test_check_for_constant_values_zeros(sat_5_data):
     """Test check_for_constant_values error with lots of zeros"""
 
+    sat_5_data = sat_5_data.copy(deep=True)
+
     sat_5_data['data'].values[:] = 0
 
     # make temporary directory
@@ -358,6 +361,7 @@ def test_check_for_constant_values_zeros(sat_5_data):
 def test_check_for_constant_values_nans(sat_5_data):
     """Test check_for_constant_values, error with nans"""
 
+    sat_5_data = sat_5_data.copy(deep=True)
     sat_5_data['data'].values[:] = np.nan
 
     # make temporary directory

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,15 +12,15 @@ from nowcasting_datamodel.models.forecast import (
 from pvnet_app.model_configs.pydantic_models import get_all_models
 
 
-def test_app(
-    db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, gsp_yields_and_systems, me_latest,
-):
 
+def test_app(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, db_url):
     """Test the app running the intraday models"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         # The app loads sat and NWP data from environment variable
         # Save out data, and set paths as environmental variables
@@ -82,14 +82,14 @@ def test_app(
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
 
 
-def test_app_no_sat(
-    db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, gsp_yields_and_systems, me_latest,
-):
+def test_app_no_sat(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
     """Test the app for the case when no satellite data is available"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         temp_nwp_path = "temp_nwp_ukv.zarr"
         os.environ["NWP_UKV_ZARR_PATH"] = temp_nwp_path
@@ -148,16 +148,17 @@ def test_app_no_sat(
 
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
 
+
 # Test for new DA model with data sampler utilisation
 # To note - Satellite omitted
-def test_app_day_ahead_data_sampler(
-    db_session, nwp_ukv_data, nwp_ecmwf_data, gsp_yields_and_systems, me_latest,
-):
+def test_app_day_ahead_data_sampler(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         temp_nwp_path = "temp_nwp_ukv.zarr"
         os.environ["NWP_UKV_ZARR_PATH"] = temp_nwp_path

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,7 @@ from pvnet_app.model_configs.pydantic_models import get_all_models
 
 
 
-def test_app(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, db_url):
+def test_app(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, db_url):
     """Test the app running the intraday models"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -48,7 +48,7 @@ def test_app(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, db
         # These imports need to come after the environ vars have been set
         from pvnet_app.app import app
 
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     all_models = get_all_models(run_extra_models=True)
 
@@ -82,7 +82,7 @@ def test_app(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, db
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
 
 
-def test_app_no_sat(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
+def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
     """Test the app for the case when no satellite data is available"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -112,7 +112,7 @@ def test_app_no_sat(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
         # Thes import needs to come after the environ vars have been set
         from pvnet_app.app import app
 
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     # Only the models which don't use satellite will be run in this case
     # The models below are the only ones which should have been run
@@ -151,7 +151,7 @@ def test_app_no_sat(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
 
 # Test for new DA model with data sampler utilisation
 # To note - Satellite omitted
-def test_app_day_ahead_data_sampler(db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
+def test_app_day_ahead_data_sampler(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -176,7 +176,7 @@ def test_app_day_ahead_data_sampler(db_session, nwp_ukv_data, nwp_ecmwf_data, db
 
         # Import at runtime to ensure environment variables are set
         from pvnet_app.app import app
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     all_models = get_all_models(get_day_ahead_only=True, use_ocf_data_sampler=True)
 

--- a/tests/test_app_legacy.py
+++ b/tests/test_app_legacy.py
@@ -14,12 +14,14 @@ from pvnet_app.model_configs.pydantic_models import get_all_models
 
 # Its nice to have this here, so we can run the latest version in production, but still use the old models
 # Once we have re trained PVnet summation models we can remove this
-def test_app_ecwmf_only(db_session, nwp_ecmwf_data, gsp_yields_and_systems, me_latest):
+def test_app_ecwmf_only(db_session, nwp_ecmwf_data, db_url):
     """Test the app for the case running model just on ecmwf"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         temp_nwp_path = "temp_nwp_ecmwf.zarr"
         os.environ["NWP_ECMWF_ZARR_PATH"] = temp_nwp_path
@@ -79,13 +81,13 @@ def test_app_ecwmf_only(db_session, nwp_ecmwf_data, gsp_yields_and_systems, me_l
 # test legacy models
 # Its nice to have this here, so we can run the latest version in production, but still use the old models
 # Once we have re trained PVnet summation models we can remove this
-def test_app_ocf_datapipes(
-    db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, gsp_yields_and_systems, me_latest,
-):
+def test_app_ocf_datapipes(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         temp_nwp_path = "temp_nwp_ukv.zarr"
         os.environ["NWP_UKV_ZARR_PATH"] = temp_nwp_path
@@ -146,14 +148,14 @@ def test_app_ocf_datapipes(
     )
 
 
-def test_app_day_ahead_model(
-    db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, gsp_yields_and_systems, me_latest,
-):
+def test_app_day_ahead_model(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         os.chdir(tmpdirname)
+
+        os.environ["DB_URL"] = db_url
 
         temp_nwp_path = "temp_nwp_ukv.zarr"
         os.environ["NWP_UKV_ZARR_PATH"] = temp_nwp_path

--- a/tests/test_app_legacy.py
+++ b/tests/test_app_legacy.py
@@ -14,7 +14,7 @@ from pvnet_app.model_configs.pydantic_models import get_all_models
 
 # Its nice to have this here, so we can run the latest version in production, but still use the old models
 # Once we have re trained PVnet summation models we can remove this
-def test_app_ecwmf_only(db_session, nwp_ecmwf_data, db_url):
+def test_app_ecwmf_only(test_t0, db_session, nwp_ecmwf_data, db_url):
     """Test the app for the case running model just on ecmwf"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -42,7 +42,7 @@ def test_app_ecwmf_only(db_session, nwp_ecmwf_data, db_url):
         # Thes import needs to come after the environ vars have been set
         from pvnet_app.app import app
 
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     # Only the models which don't use satellite will be run in this case
     # The models below are the only ones which should have been run
@@ -81,7 +81,7 @@ def test_app_ecwmf_only(db_session, nwp_ecmwf_data, db_url):
 # test legacy models
 # Its nice to have this here, so we can run the latest version in production, but still use the old models
 # Once we have re trained PVnet summation models we can remove this
-def test_app_ocf_datapipes(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
+def test_app_ocf_datapipes(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -112,7 +112,7 @@ def test_app_ocf_datapipes(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data,
         # Thes import needs to come after the environ vars have been set
         from pvnet_app.app import app
 
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     all_models = get_all_models(use_ocf_data_sampler=False)
 
@@ -148,7 +148,7 @@ def test_app_ocf_datapipes(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data,
     )
 
 
-def test_app_day_ahead_model(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
+def test_app_day_ahead_model(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -179,7 +179,7 @@ def test_app_day_ahead_model(db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_dat
         # Thes import needs to come after the environ vars have been set
         from pvnet_app.app import app
 
-        app(gsp_ids=list(range(1, 318)), num_workers=2)
+        app(t0=test_t0, gsp_ids=list(range(1, 318)), num_workers=2)
 
     all_models = get_all_models(get_day_ahead_only=True, use_ocf_data_sampler=False)
 

--- a/tests/test_datalaoder.py
+++ b/tests/test_datalaoder.py
@@ -36,7 +36,9 @@ def test_data_config():
             _ = load_yaml_configuration(temp_data_config_path)
 
 
-def test_dataloader_legacy(db_session):
+def test_dataloader_legacy(db_url):
+
+    os.environ["DB_URL"] = db_url
 
     models = get_all_models(run_extra_models=True, use_ocf_data_sampler=False)
     for model_config in models:


### PR DESCRIPTION
# Pull Request

## Description

This PR improves on the use of pytest fixtures within our tests. Some of the DataArray fixtures are moved to be sessioned scoped since we use them multiple times. The main change is around the database fixture. This PR makes the database be created and populated once with input data. After each test that uses it, all of the forecast values are deleted from the database again. This should be more efficient than what we do now - to create a new database for each test

This supersedes #153


