### PR TITLE
Refector stage 1

### DIFF
--- a/src/pvnet_app/consts.py
+++ b/src/pvnet_app/consts.py
@@ -1,9 +1,3 @@
 sat_path = "sat.zarr"
 nwp_ukv_path = "nwp_ukv.zarr"
 nwp_ecmwf_path = "nwp_ecmwf.zarr"
-
-
-uk_box = dict(
-    x_geostationary=[-996_133.85, -480_064.6],
-    y_geostationary=[4_512_606.3, 5_058_679.8],
-)

--- a/src/pvnet_app/model_configs/all_models.yaml
+++ b/src/pvnet_app/model_configs/all_models.yaml
@@ -1,7 +1,13 @@
 # Here we define all the models that are available in the app
-# Batches are prepared only once, so the extra models must be able to run on the batches created
-# to run the pvnet_v2 model
+# Batches are prepared only once, and it is assumed that all of the models configs can be unified
+# by the pvnet_app.config.get_union_of_configs function
+
 models:
+  # ------------------------------------------------------
+  # These are the new models trained with ocf-data-sampler
+  # ------------------------------------------------------
+  
+  # Currently this model uses a 30 minute satellite delay
   - name: pvnet_v2
     pvnet:
         repo: openclimatefix/pvnet_uk_region
@@ -13,8 +19,9 @@ models:
     save_gsp_sum: False
     verbose: True
     save_gsp_to_recent: true
-    
-  - name: pvnet_v2-sat0-samples-v1
+  
+  # This model uses a 0 minute satellite delay. This name is out of date
+  - name: pvnet_v2-sat0
     pvnet:
         repo: openclimatefix/pvnet_uk_region
         version: d81a9cf8adca49739ea6a3d031e36510f44744a1
@@ -22,8 +29,8 @@ models:
         repo: openclimatefix/pvnet_v2_summation
         version: dcfdc17fda8e48c387122614bec8b284eaa868b9
 
-    # single source models
-  - name: pvnet_v2-sat0-only-samples-v1"
+  # Only uses satellite data
+  - name: pvnet_v2-sat0-only
     pvnet:
       repo: openclimatefix/pvnet_uk_region
       version: 158f9aeb006dddc10ef67612a91e7175a87b8dd0
@@ -31,7 +38,8 @@ models:
       repo: openclimatefix/pvnet_v2_summation
       version: adbf9e7797fee9a5050beb8c13841696e72f99ef
 
-  - name: pvnet_v2-ukv-only-samples-v1
+  # Only uses UKV data
+  - name: pvnet_v2-ukv
     pvnet:
         repo: openclimatefix/pvnet_uk_region
         version: 4009df82e63e30546e2000728bff34b9c0520617
@@ -40,6 +48,7 @@ models:
         version: 5fc3ea16be141df38b2fad8c11a524243e9b8555
     uses_satellite_data: False
 
+  # Only uses ECMWF data
   - name: pvnet_ecmwf # this name is important as it used for blending
     pvnet:
         repo: openclimatefix/pvnet_uk_region
@@ -49,44 +58,8 @@ models:
         version: 9ddd4845cbb97b91e16de0c3370f666e1eab1c30
     ecmwf_only: True
     uses_satellite_data: False
-# This is the old model for pvnet and pvnet_ecmwf
-  - name: pvnet_v2
-    pvnet:
-      repo: openclimatefix/pvnet_uk_region
-      version: aa73cdafd1db8df3c8b7f5ecfdb160989e7639ac
-    summation:
-      repo: openclimatefix/pvnet_v2_summation
-      version: a7fd71727f4cb2b933992b2108638985e24fa5a3
-    use_adjuster: True
-    save_gsp_sum: False
-    verbose: True
-    save_gsp_to_recent: True
-    uses_ocf_data_sampler: False
-  - name: pvnet_ecmwf # this name is important as it used for blending
-    pvnet:
-        repo: openclimatefix/pvnet_uk_region
-        version: c14f7427d9854d63430aa936ce45f55d3818d033
-    summation:
-        repo: openclimatefix/pvnet_v2_summation
-        version: 4fe6b1441b6dd549292c201ed85eee156ecc220c
-    ecmwf_only: True
-    uses_satellite_data: False
-    uses_ocf_data_sampler: False
-# Legacy day ahead model without data-sampler
-  - name: pvnet_day_ahead
-    pvnet:
-        repo: openclimatefix/pvnet_uk_region_day_ahead
-        version: d87565731692a6003e43caac4feaed0f69e79272
-    summation:
-        repo: openclimatefix/pvnet_summation_uk_national_day_ahead
-        version: ed60c5d32a020242ca4739dcc6dbc8864f783a08
-    use_adjuster: True
-    save_gsp_sum: True
-    verbose: True
-    save_gsp_to_recent: True
-    day_ahead: True
-    uses_ocf_data_sampler: False
-# Day ahead model that utilises data-sampler
+
+  # Day-ahead model which does not use satellite data
   - name: pvnet_day_ahead
     pvnet:
         repo: openclimatefix/pvnet_uk_region_day_ahead
@@ -100,3 +73,48 @@ models:
     save_gsp_to_recent: True
     day_ahead: True
     uses_ocf_data_sampler: True
+  
+  # ------------------------------------------------------
+  # These are the legacy models trained with ocf_datapipes
+  # ------------------------------------------------------
+
+  # Currently this model uses a 30 minute satellite delay
+  - name: pvnet_v2
+    pvnet:
+      repo: openclimatefix/pvnet_uk_region
+      version: aa73cdafd1db8df3c8b7f5ecfdb160989e7639ac
+    summation:
+      repo: openclimatefix/pvnet_v2_summation
+      version: a7fd71727f4cb2b933992b2108638985e24fa5a3
+    use_adjuster: True
+    save_gsp_sum: False
+    verbose: True
+    save_gsp_to_recent: True
+    uses_ocf_data_sampler: False
+  
+  # Only uses ECMWF data
+  - name: pvnet_ecmwf # this name is important as it used for blending
+    pvnet:
+        repo: openclimatefix/pvnet_uk_region
+        version: c14f7427d9854d63430aa936ce45f55d3818d033
+    summation:
+        repo: openclimatefix/pvnet_v2_summation
+        version: 4fe6b1441b6dd549292c201ed85eee156ecc220c
+    ecmwf_only: True
+    uses_satellite_data: False
+    uses_ocf_data_sampler: False
+
+  # Legacy day-ahead model which uses satellite data
+  - name: pvnet_day_ahead
+    pvnet:
+        repo: openclimatefix/pvnet_uk_region_day_ahead
+        version: d87565731692a6003e43caac4feaed0f69e79272
+    summation:
+        repo: openclimatefix/pvnet_summation_uk_national_day_ahead
+        version: ed60c5d32a020242ca4739dcc6dbc8864f783a08
+    use_adjuster: True
+    save_gsp_sum: True
+    verbose: True
+    save_gsp_to_recent: True
+    day_ahead: True
+    uses_ocf_data_sampler: False

--- a/src/pvnet_app/model_configs/pydantic_models.py
+++ b/src/pvnet_app/model_configs/pydantic_models.py
@@ -22,35 +22,19 @@ class Model(BaseModel):
     pvnet: ModelHF = Field(..., title="PVNet", description="The PVNet model")
     summation: ModelHF = Field(..., title="Summation", description="The Summation model")
 
-    use_adjuster: bool | None = Field(
-        False, title="Use Adjuster", description="Whether to use the adjuster model",
-    )
-    save_gsp_sum: bool | None = Field(
-        False, title="Save GSP Sum", description="Whether to save the GSP sum",
-    )
-    verbose: bool | None = Field(
-        False, title="Verbose", description="Whether to print verbose output",
-    )
-    save_gsp_to_recent: bool | None = Field(
-        False,
-        title="Save GSP to Forecast Value Last Seven Days",
+    use_adjuster: bool = Field(False, description="Whether to use the adjuster model")
+    save_gsp_sum: bool = Field(False, description="Whether to save the GSP sum")
+    verbose: bool = Field(False, description="Whether to print verbose output")
+    save_gsp_to_recent: bool = Field(
+        False, 
         description="Whether to save the GSP to Forecast Value Last Seven Days",
     )
-    day_ahead: bool | None = Field(
-        False, title="Day Ahead", description="If this model is day ahead or not",
-    )
+    day_ahead: bool = Field(False, description="If this model is day ahead or not")
+    ecmwf_only: bool = Field(False, description="If this model is only using ecmwf data")
+    uses_satellite_data: bool = Field(True, description="If this model uses satellite data")
 
-    ecmwf_only: bool | None = Field(
-        False, title="ECMWF ONly", description="If this model is only using ecmwf data",
-    )
-
-    uses_satellite_data: bool | None = Field(
-        True, title="Uses Satellite Data", description="If this model uses satellite data",
-    )
-
-    uses_ocf_data_sampler: bool | None = Field(
+    uses_ocf_data_sampler: bool = Field(
         True,
-        title="Uses OCF Data Sampler",
         description="If this model uses data sampler, old one uses ocf_datapipes",
     )
 
@@ -58,96 +42,85 @@ class Model(BaseModel):
 class Models(BaseModel):
     """A group of ml models"""
 
-    models: list[Model] = Field(
-        ..., title="Models", description="A list of models to use for the forecast",
-    )
+    models: list[Model] = Field(..., description="A list of models to use for the forecast")
 
     @field_validator("models")
     @classmethod
     def name_must_be_unique(cls, v: list[Model]) -> list[Model]:
         """Ensure that all model names are unique, respect to using ocf_data_sampler or not"""
         names = [(model.name, model.uses_ocf_data_sampler) for model in v]
-        unique_names = set(names)
 
-        if len(names) != len(unique_names):
+        if len(names) != len(set(names)):
             raise Exception(f"Model names must be unique, names are {names}")
         return v
 
 
 def get_all_models(
-    get_ecmwf_only: bool | None = False,
-    get_day_ahead_only: bool | None = False,
-    run_extra_models: bool | None = False,
-    use_ocf_data_sampler: bool | None = True,
+    allow_use_adjuster: bool = True,
+    allow_save_gsp_sum: bool = True,
+    get_ecmwf_only: bool = False,
+    get_day_ahead_only: bool = False,
+    run_extra_models: bool = False,
+    use_ocf_data_sampler: bool = True,
 ) -> list[Model]:
     """Returns all the models for a given client
 
     Args:
+        allow_use_adjuster: If set to false all models will have use_adjuster set to false
+        allow_save_gsp_sum: If set to false all models will have save_gsp_sum set to false
         get_ecmwf_only: If only the ECMWF model should be returned
-        get_day_ahead_only: If only the day ahead model should be returned
-        run_extra_models: If extra models should be run
-        use_ocf_data_sampler: If the OCF Data Sampler should be used
+        get_day_ahead_only: If only the day-ahead model should be returned
+        run_extra_models: If all extra models should be returned
+        use_ocf_data_sampler: If the ocf-data-sampler models should be returned
     """
-    try:
-        # load models from yaml file
-        filename = files("pvnet_app.model_configs").joinpath("all_models.yaml")
+    
+    filename = files("pvnet_app.model_configs").joinpath("all_models.yaml")
 
-        with fsspec.open(filename, mode="r") as stream:
-            try:
-                models_dict = parse_config(data=stream)
-                models = Models(**models_dict)
-            except Exception as config_error:
-                log.error(f"Error parsing model configuration: {config_error}")
-                raise
+    with fsspec.open(filename, mode="r") as stream:
+        try:
+            models_dict = parse_config(data=stream)
+            models = Models(**models_dict)
+        except Exception as config_error:
+            log.error(f"Error parsing model configuration: {config_error}")
+            raise config_error
 
-        models = config_pvnet_v2_model(models)
+    # Override the use_adjuster and save_gsp_sum properties
+    if not allow_use_adjuster:
+        for model in models:
+            model.use_adjuster = False
+    if not allow_save_gsp_sum:
+        for model in models:
+            model.save_gsp_sum = False
 
-        # Apply filters based on input parameters
-        filtered_models = models.models.copy()
+    # Filter models
+    filtered_models = models.models.copy()
 
-        if get_ecmwf_only:
-            log.info("Filtering for ECMWF model only")
-            filtered_models = [model for model in filtered_models if model.ecmwf_only]
+    if get_ecmwf_only:
+        log.info("Filtering for ECMWF model only")
+        filtered_models = [model for model in filtered_models if model.ecmwf_only]
 
-        if get_day_ahead_only:
-            log.info("Filtering for Day Ahead model")
-            filtered_models = [model for model in filtered_models if model.day_ahead]
-        else:
-            log.info("Excluding Day Ahead model")
-            filtered_models = [model for model in filtered_models if not model.day_ahead]
+    if get_day_ahead_only:
+        log.info("Filtering for Day Ahead model")
+        filtered_models = [model for model in filtered_models if model.day_ahead]
+    else:
+        log.info("Excluding Day Ahead model")
+        filtered_models = [model for model in filtered_models if not model.day_ahead]
 
-        if not run_extra_models and not get_day_ahead_only and not get_ecmwf_only:
-            log.info("Limiting to default pvnet_v2 model")
-            filtered_models = [model for model in filtered_models if model.name == "pvnet_v2"]
+    if not run_extra_models and not get_day_ahead_only and not get_ecmwf_only:
+        log.info("Limiting to default pvnet_v2 model")
+        filtered_models = [model for model in filtered_models if model.name == "pvnet_v2"]
 
-        if use_ocf_data_sampler:
-            log.info("Filtering for models using OCF Data Sampler")
-            filtered_models = [model for model in filtered_models if model.uses_ocf_data_sampler]
-        else:
-            log.info("Filtering for models not using OCF Data Sampler")
-            filtered_models = [model for model in filtered_models if not model.uses_ocf_data_sampler]
+    if use_ocf_data_sampler:
+        log.info("Filtering for models using OCF Data Sampler")
+        filtered_models = [model for model in filtered_models if model.uses_ocf_data_sampler]
+    else:
+        log.info("Filtering for models not using OCF Data Sampler")
+        filtered_models = [model for model in filtered_models if not model.uses_ocf_data_sampler]
 
-        selected_model_info = [
-            (model.name, f"uses_ocf_data_sampler={model.uses_ocf_data_sampler}")
-            for model in filtered_models
-        ]
-        log.info(f"Selected models: {selected_model_info}")
+    selected_model_info = [
+        (model.name, f"uses_ocf_data_sampler={model.uses_ocf_data_sampler}")
+        for model in filtered_models
+    ]
+    log.info(f"Selected models: {selected_model_info}")
 
-        return filtered_models
-
-    except Exception as e:
-        log.error(f"Critical error in get_all_models: {e}")
-        raise
-
-
-def config_pvnet_v2_model(models):
-    """Function to adjust pvnet model"""
-    # special case for environment variables
-    use_adjuster = os.getenv("USE_ADJUSTER", "true").lower() == "true"
-    save_gsp_sum = os.getenv("SAVE_GSP_SUM", "false").lower() == "true"
-    # find index where name=pvnet_v2
-    pvnet_v2_index = 0
-    models.models[pvnet_v2_index].use_adjuster = use_adjuster
-    models.models[pvnet_v2_index].save_gsp_sum = save_gsp_sum
-
-    return models
+    return filtered_models


### PR DESCRIPTION
This makes a few of the changes from #255 

- Add function for getting boolean env variables
- Lay out the model config better
  - Also change some of the names of the extra model. I believe these names are now out of date
  - None of the actual model have been changed
- Strip back the model config to remove unnecessary bits
- Remove unneeded nested try-except block
- Move to pandas datetimes
- Fix type hinting where misleading / wrong
- Get rid of unused UK sat bounding box
- Other minor changes