### PR TITLE
partial refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ The following environment variables are used in the app:
 
 ### Optional Environment Variables
 
-- `PVNET_V2_VERSION`: The version of the PVNet V2 model to use. Default is a version above.
+- `SENTRY_DSN`: Optional link to Sentry.
+- `ENVIRONMENT`: The environment this is running in. Defaults to local.
 - `USE_ADJUSTER`: Option to use adjuster. Defaults to true.
 - `SAVE_GSP_SUM`: Option to save GSP sum for PVNet V2. Defaults to false.
 - `RUN_EXTRA_MODELS`: Option to run extra models. Defaults to false.
 - `DAY_AHEAD_MODEL`: Option to use day ahead model. Defaults to false.
-- `SENTRY_DSN`: Optional link to Sentry.
-- `ENVIRONMENT`: The environment this is running in. Defaults to local.
 - `USE_ECMWF_ONLY`: Option to use ECMWF only model. Defaults to false.
 - `USE_OCF_DATA_SAMPLER`: Option to use OCF data sampler. Defaults to true.
 - `FORECAST_VALIDATE_ZIG_ZAG_WARNING`: Threshold for warning on forecast zig-zag, defaults to 250 MW.
@@ -43,7 +42,6 @@ export DB_URL="postgresql://user:password@localhost:5432/dbname"
 export NWP_UKV_ZARR_PATH="s3://bucket/path/to/ukv.zarr"
 export NWP_ECMWF_ZARR_PATH="s3://bucket/path/to/ecmwf.zarr"
 export SATELLITE_ZARR_PATH="s3://bucket/path/to/satellite.zarr"
-export PVNET_V2_VERSION="v2.0.0"
 export USE_ADJUSTER="true"
 export SAVE_GSP_SUM="false"
 export RUN_EXTRA_MODELS="false"

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -142,7 +142,7 @@ def app(
         - NWP_UKV_ZARR_PATH
         - NWP_ECMWF_ZARR_PATH
         - SATELLITE_ZARR_PATH
-    The following are options
+    The following are optional:
         - SENTRY_DSN, optional link to sentry
         - ENVIRONMENT, the environment this is running in, defaults to local
         - USE_ADJUSTER, option to use adjuster, defaults to true
@@ -151,6 +151,10 @@ def app(
         - DAY_AHEAD_MODEL, option to use day ahead model, defaults to false
         - USE_ECMWF_ONLY, option to use ecmwf only model, defaults to false
         - USE_OCF_DATA_SAMPLER, option to use ocf_data_sampler, defaults to true
+        - FORECAST_VALIDATE_ZIG_ZAG_WARNING, threshold for forecast zig-zag warning,
+          defaults to 250 MW.
+        - FORECAST_VALIDATE_ZIG_ZAG_ERROR, threshold for forecast zig-zag error on,
+          defaults to 500 MW.
     """
 
     # ---------------------------------------------------------------------------
@@ -177,7 +181,8 @@ def app(
     use_ocf_data_sampler = get_boolean_env_var("USE_OCF_DATA_SAMPLER", default=True)
     use_adjuster = get_boolean_env_var("USE_ADJUSTER", default=True)
     save_gsp_sum = get_boolean_env_var("SAVE_GSP_SUM", default=False)
-    db_url = os.getenv("DB_URL")
+    
+    db_url = os.environ["DB_URL"] # Will raise KeyError if not set
     batch_s3_save_dir = os.getenv("SAVE_BATCHES_DIR", None)
 
     # Log version and variables
@@ -320,7 +325,7 @@ def app(
     # ---------------------------------------------------------------------------
     # Escape clause for making predictions locally
     if not write_predictions:
-        return next(iter(forecast_compilers.values())).da_abs_all
+        return forecast_compilers[0].da_abs_all
 
     # ---------------------------------------------------------------------------
     # Write predictions to database

--- a/tests/test_app_legacy.py
+++ b/tests/test_app_legacy.py
@@ -46,7 +46,9 @@ def test_app_ecwmf_only(test_t0, db_session, nwp_ecmwf_data, db_url):
 
     # Only the models which don't use satellite will be run in this case
     # The models below are the only ones which should have been run
-    all_models = get_all_models(get_ecmwf_only=True)
+    all_models = get_all_models(get_ecmwf_only=True, use_ocf_data_sampler=False)
+
+    assert len(all_models)==1
 
     # Check correct number of forecasts have been made
     # (317 GSPs + 1 National + maybe GSP-sum) = 318 or 319 forecasts

--- a/tests/test_datalaoder.py
+++ b/tests/test_datalaoder.py
@@ -36,9 +36,7 @@ def test_data_config():
             _ = load_yaml_configuration(temp_data_config_path)
 
 
-def test_datapipes_dataloader(db_url):
-
-    os.environ["DB_URL"] = db_url
+def test_datapipes_dataloader(db_url, test_t0):
 
     models = get_all_models(run_extra_models=True, use_ocf_data_sampler=False)
     for model_config in models:
@@ -49,12 +47,11 @@ def test_datapipes_dataloader(db_url):
             revision=model_config.pvnet.version,
         )
 
-        t0 = pd.Timestamp.now(tz="UTC").replace(tzinfo=None).floor(timedelta(minutes=30))
-
         _ = get_datapipes_dataloader(
             config_filename=data_config_path,
-            t0=t0,
+            t0=test_t0,
             gsp_ids=list(range(1, 10)),
             batch_size=2,
             num_workers=1,
+            db_url=db_url,
         )

--- a/tests/test_datalaoder.py
+++ b/tests/test_datalaoder.py
@@ -7,7 +7,7 @@ from ocf_data_sampler.config import load_yaml_configuration
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
 
 from pvnet_app.config import modify_data_config_for_production
-from pvnet_app.dataloader import get_legacy_dataloader
+from pvnet_app.dataloader import get_datapipes_dataloader
 from pvnet_app.model_configs.pydantic_models import get_all_models
 
 
@@ -36,7 +36,7 @@ def test_data_config():
             _ = load_yaml_configuration(temp_data_config_path)
 
 
-def test_dataloader_legacy(db_url):
+def test_datapipes_dataloader(db_url):
 
     os.environ["DB_URL"] = db_url
 
@@ -51,7 +51,7 @@ def test_dataloader_legacy(db_url):
 
         t0 = pd.Timestamp.now(tz="UTC").replace(tzinfo=None).floor(timedelta(minutes=30))
 
-        _ = get_legacy_dataloader(
+        _ = get_datapipes_dataloader(
             config_filename=data_config_path,
             t0=t0,
             gsp_ids=list(range(1, 10)),


### PR DESCRIPTION


## Description

This is another part of the refactor.

- Move batch device handling and torch.no_grad into the forecast compiler
- Clean up the dataloaders and switching between the datapipes and data-sampler versions
- Clean up some of the logging set up
- Remove `PVNET_V2_VERSION` and `PVNET_V2_SUMMATION_VERSION` from docstrings as these aren't actually used anymore
- Reorder some of the `app()` function setup

