### PR TITLE
fix legacy ecmwf model used

### DIFF
--- a/tests/test_app_legacy.py
+++ b/tests/test_app_legacy.py
@@ -1,3 +1,5 @@
+"""Test the app using the legacy dataloader - ocf_datapipes"""
+
 import os
 import tempfile
 
@@ -12,8 +14,7 @@ from nowcasting_datamodel.models.forecast import (
 from pvnet_app.model_configs.pydantic_models import get_all_models
 
 
-# Its nice to have this here, so we can run the latest version in production, but still use the old models
-# Once we have re trained PVnet summation models we can remove this
+
 def test_app_ecwmf_only(test_t0, db_session, nwp_ecmwf_data, db_url):
     """Test the app for the case running model just on ecmwf"""
 
@@ -46,7 +47,7 @@ def test_app_ecwmf_only(test_t0, db_session, nwp_ecmwf_data, db_url):
 
     # Only the models which don't use satellite will be run in this case
     # The models below are the only ones which should have been run
-    all_models = get_all_models(get_ecmwf_only=True)
+    all_models = get_all_models(get_ecmwf_only=True, use_ocf_data_sampler=False)
 
     # Check correct number of forecasts have been made
     # (317 GSPs + 1 National + maybe GSP-sum) = 318 or 319 forecasts
@@ -78,10 +79,8 @@ def test_app_ecwmf_only(test_t0, db_session, nwp_ecmwf_data, db_url):
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
 
 
-# test legacy models
-# Its nice to have this here, so we can run the latest version in production, but still use the old models
-# Once we have re trained PVnet summation models we can remove this
-def test_app_ocf_datapipes(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
+
+def test_app(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data, db_url):
     """Test the app running the day ahead model"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Previously in this test module, the ECMWF-only model was actually using the ocf-data-sampler version. I think the intended behaviour is that all tests in this module use the ocf_datapipes versions