### PR TITLE
Hot fix get_pvnet_satellite_spatial_bounds

### DIFF
--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -266,10 +266,10 @@ def get_pvnet_satellite_spatial_bounds(
     # This gives us a bounding box used by PVNet
     locations = get_gsp_locations()
 
-    xmin = -np.inf
-    xmax = np.inf
-    ymin = -np.inf
-    ymax = np.inf
+    xmin = np.inf
+    xmax = -np.inf
+    ymin = np.inf
+    ymax = -np.inf
 
     for location in locations:
         
@@ -280,10 +280,10 @@ def get_pvnet_satellite_spatial_bounds(
             height_pixels=height_pixels,
         )
         
-        xmin = min(xmin, da_slice.x_geostationary.min())
-        xmax = max(xmax, da_slice.x_geostationary.max())
-        ymin = min(ymin, da_slice.y_geostationary.min())
-        xmax = max(ymax, da_slice.y_geostationary.max())
+        xmin = min(xmin, da_slice.x_geostationary.min().item())
+        xmax = max(xmax, da_slice.x_geostationary.max().item())
+        ymin = min(ymin, da_slice.y_geostationary.min().item())
+        ymax = max(ymax, da_slice.y_geostationary.max().item())
 
     # Allow for coords to be reversed
     if ds.x_geostationary[-1] > ds.x_geostationary[0]:


### PR DESCRIPTION
# Pull Request

Fixes the `get_pvnet_satellite_spatial_bounds()` function which had a couple of small bugs. 

- Poor choice in initialisation values
- Typos


I tested this locally to see which are of the current live satellite would be selected. The area is shown in the image below.
![download - 2025-04-01T182637 949](https://github.com/user-attachments/assets/26ff5572-8f88-4307-b94a-0ce5e93de9a6)

