### PR TITLE
nowcasting_datamodel==1.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "PVNet-summation==0.3.7",
     "fsspec[s3]==2025.2.0",
     "huggingface-hub==0.28.1",
-    "nowcasting_datamodel==1.6.2",
+    "nowcasting_datamodel==1.7.2",
     "numpy==2.0.0",
     "ocf_data_sampler==0.2.22",
     "pandas==2.2.3",


### PR DESCRIPTION
# Pull Request

## Description

Update to nowcasting_datamodel==1.7.2. This helps with 

Helps with https://github.com/openclimatefix/uk-pv-national-gsp-api/issues/459

## How Has This Been Tested?

- [x] CI tests and worked with blend using this dm version

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
