### PR TITLE
Timestamp information added when error would occur

### DIFF
--- a/src/pvnet_app/validate_forecast.py
+++ b/src/pvnet_app/validate_forecast.py
@@ -127,11 +127,13 @@ def check_forecast_positive_during_daylight(
 
     # Check if forecast values are > 0 when sun elevation is over the threshold
     daylight_mask = solpos["elevation"] > sun_elevation_lower_limit
-
+    Timestamps = national_forecast[daylight_mask & (national_forecast <= 0)].index
+    Timestamps_str = ", ".join([str(t) for t in Timestamps])
     if not (national_forecast[daylight_mask] > 0).all():
         logger.warning(
             f"{model_name}: Forecast values must be > 0 when sun elevation > "
             f"{sun_elevation_lower_limit} degree."
+            f"Timestamps: {Timestamps_str}"
         )
         forecast_okay = False
     


### PR DESCRIPTION
To improve the warning message timestamps added.

# Pull Request

## Description

I added Timestamp of time when an error will occur.

Fixes #

## How Has This Been Tested?

(national_forecast[daylight_mask & (national_forecast <= 0)].index     

properly finds timestamps where it's daylight And forecast is ≤ 0

-  Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

-  Yes

## Checklist:

- [ ✔️] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [✔️ ] I have performed a self-review of my own code
- [✔️ ] I have made corresponding changes to the documentation
- [ ✔️] I have checked my code and corrected any misspellings
