### PR TITLE
add option for 15 minute satellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The following environment variables are used in the app:
 #### These control the data sources
 
 - `SATELLITE_SCALE_FACTOR`: The scale factor for the satellite data. Defaults to 1023. 
+- `SATELLITE_15_ZARR_PATH`: The path to the 15 minute satellite data in Zarr format. If 
+this is not set then the `SATELLITE_ZARR_PATH` is used by `.zarr` is repalced with `_15.zarr`
 
 #### These control the model(s) run
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -26,6 +26,7 @@ from pvnet_app.forecaster import Forecaster
 from pvnet_app.validate_forecast import validate_forecast
 from pvnet_app.consts import __version__
 
+from src.pvnet_app.data.satellite import get_satellite_source_paths
 
 try:
     __pvnet_version__ = version("pvnet")
@@ -140,11 +141,8 @@ def app(
     ecmwf_source_path = os.getenv("NWP_ECMWF_ZARR_PATH", None)
     ukv_source_path = os.getenv("NWP_UKV_ZARR_PATH", None)
     cloudcasting_source_path = os.getenv("CLOUDCASTING_ZARR_PATH", None)
-    sat_source_path_5 = os.getenv("SATELLITE_ZARR_PATH", None)
-    sat_source_path_15 = os.getenv("SATELLITE_15_ZARR_PATH", None)
-    if sat_source_path_15 is None and sat_source_path_5 is not None:
-        sat_source_path_15 = sat_source_path_5.replace(".zarr", "_15.zarr")
-    
+    sat_source_path_5, sat_source_path_15 = get_satellite_source_paths()
+
     # --- Log version and variables
     logger.info(f"Using `pvnet` library version: {__pvnet_version__}")
     logger.info(f"Using `pvnet_app` library version: {__version__}")
@@ -383,6 +381,7 @@ def app(
             model_configs=model_configs, 
             raise_if_missing=raise_model_failure,
         )
+
 
 if __name__ == "__main__":
     typer.run(app)

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -141,9 +141,9 @@ def app(
     ukv_source_path = os.getenv("NWP_UKV_ZARR_PATH", None)
     cloudcasting_source_path = os.getenv("CLOUDCASTING_ZARR_PATH", None)
     sat_source_path_5 = os.getenv("SATELLITE_ZARR_PATH", None)
-    sat_source_path_15 = (
-        None if (sat_source_path_5 is None) else sat_source_path_5.replace(".zarr", "_15.zarr")
-    )
+    sat_source_path_15 = os.getenv("SATELLITE_15_ZARR_PATH", None)
+    if sat_source_path_15 is None and sat_source_path_5 is not None:
+        sat_source_path_15 = sat_source_path_5.replace(".zarr", "_15.zarr")
     
     # --- Log version and variables
     logger.info(f"Using `pvnet` library version: {__pvnet_version__}")

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -560,3 +560,14 @@ class SatelliteDownloader:
         """Remove the downloaded data"""
         for path in [self.destination_path, self.destination_path_5, self.destination_path_15]:
             shutil.rmtree(path, ignore_errors=True)
+
+
+def get_satellite_source_paths() -> (str | None, str | None):
+    """ Get the paths to the satellite data from environment variables"""
+    sat_source_path_5 = os.getenv("SATELLITE_ZARR_PATH", None)
+    sat_source_path_15 = os.getenv("SATELLITE_15_ZARR_PATH", None)
+    if sat_source_path_15 is None and sat_source_path_5 is not None:
+        sat_source_path_15 = sat_source_path_5.replace(".zarr", "_15.zarr")
+    logger.info(
+        f"Satellite source paths: 5-minute: {sat_source_path_5}, 15-minute: {sat_source_path_15}")
+    return sat_source_path_5, sat_source_path_15

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -13,6 +13,7 @@ from pvnet_app.data.satellite import (
     extend_satellite_data_with_nans,
     interpolate_missing_satellite_timestamps,
     SatelliteDownloader,
+    get_satellite_source_paths,
 )
 
 # ------------------------------------------------------------
@@ -344,3 +345,22 @@ def test_contains_too_many_of_value(sat_5_data):
     ds = sat_5_data.copy(deep=True)
     ds['data'].values[:] = np.nan
     assert contains_too_many_of_value(ds, value=np.nan, threshold=0.1)
+
+
+def test_get_satellite_source_paths():
+    os.environ["SATELLITE_ZARR_PATH"] = "temp_sat.zarr.zip"
+    path_5, path_15 = get_satellite_source_paths()
+
+    assert path_5 == "temp_sat.zarr.zip"
+    assert path_15 == "temp_sat_15.zarr.zip"
+
+    os.environ["SATELLITE_ZARR_PATH"] = "temp_sat.zarr.zip"
+    os.environ["SATELLITE_15_ZARR_PATH"] = "15_temp_sat.zarr.zip"
+    path_5, path_15 = get_satellite_source_paths()
+
+    assert path_5 == "temp_sat.zarr.zip"
+    assert path_15 == "15_temp_sat.zarr.zip"
+
+    # remove environment variables
+    del os.environ["SATELLITE_ZARR_PATH"]
+    del os.environ["SATELLITE_15_ZARR_PATH"]


### PR DESCRIPTION
# Pull Request

## Description

- 15 minute satellite can be set with seperate path compared to 5 minute satellite data. Default behaviour is still the same
- https://github.com/openclimatefix/uk-pvnet-app/issues/330
- This is needed for https://github.com/openclimatefix/airflow-dags/issues/145


## How Has This Been Tested?

- added a test

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
