### PR TITLE
Add model with 2NWP and 0-min sat delay

### DIFF
--- a/src/pvnet_app/model_configs/all_models.yaml
+++ b/src/pvnet_app/model_configs/all_models.yaml
@@ -48,6 +48,22 @@ models:
     save_gsp_to_recent: False
     uses_satellite_data: True
 
+  # This uses 2NWP + satellite with 0-minute delay
+  - name: pvnet_v2_sat0
+    pvnet:
+        repo: openclimatefix/pvnet_uk_region
+        commit: bd4cced6f00dd40a3858d49b3904ffaf325e6874
+    summation:
+        repo: openclimatefix/pvnet_v2_summation
+        commit: 7f4cb614e85c2a1391c5fcd73d8c457414566a7c
+    is_critical: False
+    is_day_ahead: False
+    use_adjuster: False
+    save_gsp_sum: False
+    verbose_logging: False
+    save_gsp_to_recent: False
+    uses_satellite_data: True
+
   # Only uses ECMWF data
   - name: pvnet_ecmwf # This name is important as it used for blending
     pvnet:

--- a/tests/model_configs/test_pydantic_models.py
+++ b/tests/model_configs/test_pydantic_models.py
@@ -4,7 +4,7 @@ from pvnet_app.model_configs.pydantic_models import get_all_models
 def test_get_all_models():
     """Test for getting all models"""
     models = get_all_models()
-    assert len(models) == 5
+    assert len(models) == 6
     assert models[0].name == "pvnet_v2"
 
 


### PR DESCRIPTION
# Pull Request

## Description

Add a new PVNet intraday model which uses 2NWP + satellite with a 0-minute delay

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
