### PR TITLE
Merge intraday and day-ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ this is not set then the `SATELLITE_ZARR_PATH` is used by `.zarr` is repalced wi
 #### These control the model(s) run
 
 - `RUN_CRITICAL_MODELS_ONLY`: Option to run critical models only. Defaults to false.
-- `DAY_AHEAD_MODEL`: Option to use day ahead model. Defaults to false.
 
 #### These control the saved results
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -92,7 +92,6 @@ def app(
           adjuster option in the model configs so it is not used. Defaults to true.
         - ALLOW_SAVE_GSP_SUM: Option to allow model to save the GSP sum. If false this overwrites 
           the model configs so saving of the GSP sum is not used. Defaults to false.
-        - DAY_AHEAD_MODEL, option to use day ahead model, defaults to false
         - RUN_CRITICAL_MODELS_ONLY, option to run critical models only, defaults to false
         - FORECAST_VALIDATE_ZIG_ZAG_WARNING, threshold for forecast zig-zag warning,
           defaults to 250 MW.
@@ -121,7 +120,6 @@ def app(
         assert len(gsp_ids)>0, "No GSP IDs provided"
 
     # --- Unpack the environment variables
-    use_day_ahead_model = get_boolean_env_var("DAY_AHEAD_MODEL", default=False)
     run_critical_models_only = get_boolean_env_var("RUN_CRITICAL_MODELS_ONLY", default=False)
     allow_adjuster = get_boolean_env_var("ALLOW_ADJUSTER", default=True)
     allow_save_gsp_sum = get_boolean_env_var("ALLOW_SAVE_GSP_SUM", default=False)
@@ -144,7 +142,6 @@ def app(
     logger.info(f"Using `pvnet_app` library version: {__version__}")
     logger.info(f"Making forecast for init time: {t0}")
     logger.info(f"Making forecast for GSP IDs: {gsp_ids}")
-    logger.info(f"Using day ahead model: {use_day_ahead_model}")
     logger.info(f"Running critical models only: {run_critical_models_only}")
     logger.info(f"Allow adjuster: {allow_adjuster}")
     logger.info(f"Allow saving GSP sum: {allow_save_gsp_sum}")
@@ -154,7 +151,6 @@ def app(
         allow_adjuster=allow_adjuster,
         allow_save_gsp_sum=allow_save_gsp_sum,
         get_critical_only=run_critical_models_only,
-        get_day_ahead_only=use_day_ahead_model,
     )
 
     if len(model_configs)==0:

--- a/src/pvnet_app/model_configs/pydantic_models.py
+++ b/src/pvnet_app/model_configs/pydantic_models.py
@@ -70,7 +70,6 @@ def get_all_models(
     allow_adjuster: bool = True,
     allow_save_gsp_sum: bool = True,
     get_critical_only: bool = False,
-    get_day_ahead_only: bool = False,
 ) -> list[ModelConfig]:
     """Returns all the models for a given client
 
@@ -78,7 +77,6 @@ def get_all_models(
         allow_adjuster: If set to false, all models will have use_adjuster set to false
         allow_save_gsp_sum: If set to false, all models will have save_gsp_sum set to false
         get_critical_only: If only the critical models should be returned
-        get_day_ahead_only: If only the day-ahead model should be returned
     """
     
     filename = files("pvnet_app.model_configs").joinpath("all_models.yaml")
@@ -105,13 +103,6 @@ def get_all_models(
     if get_critical_only:
         log.info("Filtering to critical models")
         filtered_models = [model for model in filtered_models if model.is_critical]
-
-    if get_day_ahead_only:
-        log.info("Filtering to day-ahead models")
-        filtered_models = [model for model in filtered_models if model.is_day_ahead]
-    else:
-        log.info("Filtering to intra-day models")
-        filtered_models = [model for model in filtered_models if not model.is_day_ahead]
 
     # We should always have at least one model 
     if len(filtered_models)==0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,9 +178,7 @@ def config_filename():
 
 def make_sat_data(test_t0, delay_mins, freq_mins):
     # Load dataset which only contains coordinates, but no data
-    ds = xr.open_zarr(
-        f"{test_data_dir}/non_hrv_shell.zarr",
-    ).compute()
+    ds = xr.open_zarr(f"{test_data_dir}/non_hrv_shell.zarr").compute()
 
     # Expand time dim to be len 36 = 3 hours of 5 minute data
     n_hours = 3

--- a/tests/model_configs/test_pydantic_models.py
+++ b/tests/model_configs/test_pydantic_models.py
@@ -4,20 +4,14 @@ from pvnet_app.model_configs.pydantic_models import get_all_models
 def test_get_all_models():
     """Test for getting all models"""
     models = get_all_models()
-    assert len(models) == 6
+    assert len(models) == 7
     assert models[0].name == "pvnet_v2"
 
 
 def test_get_all_models_get_critical_only():
     """Test for getting all the critcal models"""
     models = get_all_models(get_critical_only=True)
-    assert len(models) == 2
+    assert len(models) == 3
     assert all(m.is_critical for m in models)
 
-
-def test_get_all_models_get_day_ahead_only():
-    """Test for getting all the day ahead models"""
-    models = get_all_models(get_day_ahead_only=True)
-    assert len(models) == 1
-    assert models[0].is_day_ahead
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -46,7 +46,6 @@ def test_app(
         # Set environmental variables
         os.environ["RUN_CRITICAL_MODELS_ONLY"] = "False"
         os.environ["ALLOW_SAVE_GSP_SUM"] = "True"
-        os.environ["DAY_AHEAD_MODEL"] = "False"
         os.environ["FORECAST_VALIDATE_ZIG_ZAG_ERROR"] = "100000"
         os.environ["FORECAST_VALIDATION_SUN_ELEVATION_LOWER_LIMIT"] = "90"
 
@@ -58,31 +57,32 @@ def test_app(
     # Check correct number of forecasts have been made
     # (Number of GSPs + 1 National + maybe GSP-sum) forecasts
     # Forecast made with multiple models
-    expected_forecast_results = 0
+    expected_num_forecasts = 0
+    expected_num_forecast_values = 0
     for model_config in all_models:
-        expected_forecast_results += NUM_GSPS + 1 + model_config.save_gsp_sum
+        # The number of forecasts
+        num_forecasts = NUM_GSPS + 1 + model_config.save_gsp_sum
+        expected_num_forecasts += num_forecasts
+        # The number of forecast values - 16 for intraday, 36 for day-ahead)
+        expected_num_forecast_values += num_forecasts * (36 if model_config.is_day_ahead else 16)
 
     forecasts = db_session.query(ForecastSQL).all()
     # Doubled for historic and forecast
-    assert len(forecasts) == expected_forecast_results * 2
+    assert len(forecasts) == expected_num_forecasts * 2
 
     # Check probabilistic added
     assert "90" in forecasts[0].forecast_values[0].properties
     assert "10" in forecasts[0].forecast_values[0].properties
 
-    # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == expected_forecast_results * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_forecast_results * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == expected_num_forecast_values
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_num_forecast_values
 
-    expected_forecast_results = 0
+    expected_num_forecast_values = 0
     for model_config in all_models:
-        # National
-        expected_forecast_results += 1
-        # GSP
-        expected_forecast_results += NUM_GSPS * model_config.save_gsp_to_recent
-        expected_forecast_results += model_config.save_gsp_sum  # optional Sum of GSPs
+        num_forecasts = 1 + NUM_GSPS * model_config.save_gsp_to_recent + model_config.save_gsp_sum
+        expected_num_forecast_values += num_forecasts * (36 if model_config.is_day_ahead else 16)
 
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_num_forecast_values
 
 
 def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
@@ -105,7 +105,6 @@ def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
 
         os.environ["RUN_CRITICAL_MODELS_ONLY"] = "False"
         os.environ["ALLOW_SAVE_GSP_SUM"] = "True"
-        os.environ["DAY_AHEAD_MODEL"] = "False"
         os.environ["FORECAST_VALIDATE_ZIG_ZAG_ERROR"] = "100000"
         os.environ["FORECAST_VALIDATION_SUN_ELEVATION_LOWER_LIMIT"] = "90"
 
@@ -142,58 +141,3 @@ def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
         expected_forecast_results += model_config.save_gsp_sum  # optional Sum of GSPs
 
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
-
-
-def test_app_day_ahead(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
-    """Test the app running the day ahead model"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-
-        os.chdir(tmpdirname)
-
-        os.environ["DB_URL"] = db_url
-
-        os.environ["NWP_UKV_ZARR_PATH"] = temp_nwp_path = "temp_nwp_ukv.zarr"
-        nwp_ukv_data.to_zarr(temp_nwp_path)
-
-        os.environ["NWP_ECMWF_ZARR_PATH"] = temp_nwp_path = "temp_nwp_ecmwf.zarr"
-        nwp_ecmwf_data.to_zarr(temp_nwp_path)
-
-        os.environ["SATELLITE_ZARR_PATH"] = "nonexistent_sat.zarr.zip"
-        os.environ["DAY_AHEAD_MODEL"] = "True"
-        os.environ["ALLOW_SAVE_GSP_SUM"] = "True"
-        os.environ["FORECAST_VALIDATE_ZIG_ZAG_ERROR"] = "100000"
-        os.environ["FORECAST_VALIDATION_SUN_ELEVATION_LOWER_LIMIT"] = "90"
-
-        app(t0=test_t0)
-
-    all_models = get_all_models(get_day_ahead_only=True)
-
-    # Check correct number of forecasts have been made
-    expected_forecast_results = 0
-    for model_config in all_models:
-        expected_forecast_results += NUM_GSPS + 1 + model_config.save_gsp_sum
-
-    forecasts = db_session.query(ForecastSQL).all()
-    # Doubled for historic and forecast
-    assert len(forecasts) == expected_forecast_results * 2
-
-    # Check probabilistic added
-    assert "90" in forecasts[0].forecast_values[0].properties
-    assert "10" in forecasts[0].forecast_values[0].properties
-
-    # 72 time steps in forecast
-    expected_forecast_timesteps = 72
-
-    assert (
-        len(db_session.query(ForecastValueSQL).all())
-        == expected_forecast_results * expected_forecast_timesteps
-    )
-    assert (
-        len(db_session.query(ForecastValueLatestSQL).all())
-        == expected_forecast_results * expected_forecast_timesteps
-    )
-    assert (
-        len(db_session.query(ForecastValueSevenDaysSQL).all())
-        == expected_forecast_results * expected_forecast_timesteps
-    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,6 +15,40 @@ from pvnet_app.app import app
 NUM_GSPS = 331
 
 
+def check_number_of_forecasts(model_configs, db_session):
+    """Check the app has added the expected number of forecast values to the database"""
+
+    # Check correct number of forecasts have been made
+    # (Number of GSPs + 1 National + maybe GSP-sum) forecasts
+    # Forecast made with multiple models
+    expected_num_forecasts = 0
+    expected_num_forecast_values = 0
+    for model_config in model_configs:
+        # The number of forecasts
+        num_forecasts = NUM_GSPS + 1 + model_config.save_gsp_sum
+        expected_num_forecasts += num_forecasts
+        # The number of forecast values - 16 for intraday, 36 for day-ahead)
+        expected_num_forecast_values += num_forecasts * (72 if model_config.is_day_ahead else 16)
+
+    forecasts = db_session.query(ForecastSQL).all()
+    # Doubled for historic and forecast
+    assert len(forecasts) == expected_num_forecasts * 2
+
+    # Check probabilistic added
+    assert "90" in forecasts[0].forecast_values[0].properties
+    assert "10" in forecasts[0].forecast_values[0].properties
+
+    assert len(db_session.query(ForecastValueSQL).all()) == expected_num_forecast_values
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_num_forecast_values
+
+    expected_num_forecast_values = 0
+    for model_config in model_configs:
+        num_forecasts = 1 + NUM_GSPS * model_config.save_gsp_to_recent + model_config.save_gsp_sum
+        expected_num_forecast_values += num_forecasts * (72 if model_config.is_day_ahead else 16)
+
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_num_forecast_values
+
+
 def test_app(
     test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, sat_5_data_zero_delay, 
     cloudcasting_data, db_url
@@ -52,37 +86,9 @@ def test_app(
         # Run prediction
         app(t0=test_t0)
 
-    all_models = get_all_models(get_critical_only=False)
+    model_configs = get_all_models(get_critical_only=False)
+    check_number_of_forecasts(model_configs, db_session)
 
-    # Check correct number of forecasts have been made
-    # (Number of GSPs + 1 National + maybe GSP-sum) forecasts
-    # Forecast made with multiple models
-    expected_num_forecasts = 0
-    expected_num_forecast_values = 0
-    for model_config in all_models:
-        # The number of forecasts
-        num_forecasts = NUM_GSPS + 1 + model_config.save_gsp_sum
-        expected_num_forecasts += num_forecasts
-        # The number of forecast values - 16 for intraday, 36 for day-ahead)
-        expected_num_forecast_values += num_forecasts * (36 if model_config.is_day_ahead else 16)
-
-    forecasts = db_session.query(ForecastSQL).all()
-    # Doubled for historic and forecast
-    assert len(forecasts) == expected_num_forecasts * 2
-
-    # Check probabilistic added
-    assert "90" in forecasts[0].forecast_values[0].properties
-    assert "10" in forecasts[0].forecast_values[0].properties
-
-    assert len(db_session.query(ForecastValueSQL).all()) == expected_num_forecast_values
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_num_forecast_values
-
-    expected_num_forecast_values = 0
-    for model_config in all_models:
-        num_forecasts = 1 + NUM_GSPS * model_config.save_gsp_to_recent + model_config.save_gsp_sum
-        expected_num_forecast_values += num_forecasts * (36 if model_config.is_day_ahead else 16)
-
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_num_forecast_values
 
 
 def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
@@ -112,32 +118,7 @@ def test_app_no_sat(test_t0, db_session, nwp_ukv_data, nwp_ecmwf_data, db_url):
 
     # Only the models which don't use satellite will be run in this case
     # The models below are the only ones which should have been run
-    all_models = get_all_models()
-    all_models = [model for model in all_models if not model.uses_satellite_data]
+    model_configs = get_all_models()
+    model_configs = [model for model in model_configs if not model.uses_satellite_data]
 
-    # Check correct number of forecasts have been made
-    expected_forecast_results = 0
-    for model_config in all_models:
-        expected_forecast_results += (NUM_GSPS + 1) + model_config.save_gsp_sum
-
-    forecasts = db_session.query(ForecastSQL).all()
-    # Doubled for historic and forecast
-    assert len(forecasts) == expected_forecast_results * 2
-
-    # Check probabilistic added
-    assert "90" in forecasts[0].forecast_values[0].properties
-    assert "10" in forecasts[0].forecast_values[0].properties
-
-    # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == expected_forecast_results * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_forecast_results * 16
-
-    expected_forecast_results = 0
-    for model_config in all_models:
-        # National
-        expected_forecast_results += 1
-        # GSP
-        expected_forecast_results += NUM_GSPS * model_config.save_gsp_to_recent
-        expected_forecast_results += model_config.save_gsp_sum  # optional Sum of GSPs
-
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
+    check_number_of_forecasts(model_configs, db_session)

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
@@ -38,7 +37,3 @@ def test_model_loading():
             assert isinstance(summation_model, SummationBaseModel)
         else:
             assert summation_model is None
-        
-        # Assertion major required attributes actually exist
-        assert hasattr(pvnet_model, "forecast_len")
-        assert hasattr(pvnet_model, "output_quantiles")


### PR DESCRIPTION
After #350, we can run the intraday and day-ahead models in the same app run. This will simplify our live deployment by removing duplication and is more efficient